### PR TITLE
Fixing bug where target is inserted if the xml is not there

### DIFF
--- a/bin/xlifftranslate.js
+++ b/bin/xlifftranslate.js
@@ -98,6 +98,10 @@ function run() {
         tasks.push(function () {
           return function (callback) {
             var target = node.find('target');
+            if (target.length == 0) {
+              node.append('<target></target>');
+              target = node.find('target');
+            }
             if (target.attr('state') === 'translated') {
               callback();
               return;


### PR DESCRIPTION
Add target xml if non-existent. iOS exported xliff files do not always have the target populated