### PR TITLE
Throttle to one request at a time, with 1/5 of a second wait. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ### Examples
 
-> To run, make sure your Google Translate API Credendials are in your environment:
+> To run, make sure your Google Translate API Credentials are in your environment:
 
 `export GOOGLE_APPLICATION_CREDENTIALS=service_account.json` 
 

--- a/bin/xlifftranslate.js
+++ b/bin/xlifftranslate.js
@@ -5,7 +5,8 @@ var argv = require('minimist')(process.argv.slice(2));
 var cheerio = require('cheerio');
 var fs = require('fs');
 var path = require('path');
-var runAsync = require("async");
+var async = require('async');
+var sleep = require('sleep')
 var Translate = require('@google-cloud/translate');
 var translate = Translate();
 
@@ -17,6 +18,7 @@ XliffTranslate.launch({
   verbose: argv.verbose
 }, invoke);
 
+// Primary entry point. Print app settings.
 function invoke(env) {
 
   if (argv.verbose) {
@@ -36,8 +38,10 @@ function invoke(env) {
   run();
 }
 
+// Secondary entry point. Run the program.
 function run() {
 
+  // Parse All Command Arguments, set defaults if unset.
   var ignoreTextArgv = argv.ignoreText || '';
   var ignoreDelimiter = argv.ignoreDelimiter || ' ';
   var verbose = argv.verbose === 'true' ||
@@ -51,15 +55,20 @@ function run() {
       argv.skipDifferent === true || false;
 
   var i18nPath = argv.i18nPath || process.cwd();
+
+  // Start by reading the directory for translation files.
   fs.readdir(i18nPath, function (err, files) {
+
     if (err) {
       console.error('Could not list the directory.', err);
       process.exit(1);
     }
     
+    // START: Process each file.
     files.forEach(function (file, index) {
+
+      // Look for locale/lang in filename (e.g. messages.de.xliff)
       var fileParts = file.split('.');
-      // Look for locale in filename (e.g. messages.de.xliff)
       if (fileParts.length < 3) {
           if (fileParts.length == 2) {
               var newFileParts = ['whocares', fileParts[0], fileParts[1]];
@@ -71,7 +80,6 @@ function run() {
           }
       }
 
-      var tasks = [];
       var locale = fileParts[1];
       var lang = locale;
       if (lang.indexOf('-') !== -1) {
@@ -114,55 +122,60 @@ function run() {
         $("body").append(elem);
       }
 
-      // Translate
+      // Define a worker queue with defined translating callback function.
+      var q = async.queue(function (task, callback) {
+        var node = task.node
+        var text = node.find('source').html();
+        var source = node.find('source');
+        var target = node.find('target');
+        if (target.attr('state') === 'translated' ) {
+          callback();
+          return;
+        }
+
+        // skip if the caller wants to skip source/target that are unequal.
+        if (skipDifferent === true && source !== target) {
+          console.info("Skipped: " + text + " due to skipDifferent flag");
+          callback();
+          return;
+        }
+
+        text = replaceIgnoreTextWithPlaceholders(ignoreText, text, false);
+
+        translate.translate(text, lang).then(function (results) {
+          var translations = results[0];
+          var translation = Array.isArray(translations) ? translations[0] : translations;
+
+          translation = replaceIgnoreTextWithPlaceholders(ignoreText, translation, true);
+          if (verbose) {
+            console.log(`${locale}: ${text} => ${translation}`);
+          }
+          target.attr('xml:lang', locale);
+          target.attr('state', 'translated');
+          target.html(translation);
+          sleep.usleep(200)
+          callback();
+        }).catch(function (err) {
+          if (err.code === 400) {
+            console.error(`Error: ${locale} is not a valid locale`);
+          } else {
+            console.error(err);
+          }
+          callback();
+        });
+      }, 1);
+
+      // Translate - I.E. pass each node to the aync worker pool 'q' in order to run the translation function on the node.
       $("trans-unit").each(function () {
         var node = $(this);
-        var text = node.find('source').html();
-        tasks.push(function () {
-          return function (callback) {
-            var source = node.find('source');
-            var target = node.find('target');
-            if (target.attr('state') === 'translated' ) {
-              callback();
-              return;
-            }
-
-            // skip if the caller wants to skip source/target that are unequal.
-            if (skipDifferent === true && source !== target) {
-              callback();
-              return;
-            }
-
-            text = replaceIgnoreTextWithPlaceholders(ignoreText, text, false);
-
-            translate.translate(text, lang).then(function (results) {
-              var translations = results[0];
-              var translation = Array.isArray(translations) ? translations[0] : translations;
-
-              translation = replaceIgnoreTextWithPlaceholders(ignoreText, translation, true);
-              if (verbose) {
-                console.log(`${locale}: ${text} => ${translation}`);
-              }
-              target.attr('xml:lang', locale);
-              target.attr('state', 'translated');
-              target.html(translation);
-              callback();
-            }).catch(function (err) {
-              if (err.code === 400) {
-                console.error(`Error: ${locale} is not a valid locale`);
-              } else {
-                console.error(err);
-              }
-              callback();
-            });
-          }
-        } ());
-      });
-      runAsync.parallel(tasks, function () {
-        fs.writeFileSync(filePath, $.xml());
+        q.push({'node': node}, function(err) {
+          // Precondition, node has been parsed, and xml file has been replaced with translations.
+          fs.writeFileSync(filePath, $.xml());
+        });
       });
     });
   });
+  console.info("Translation Completed");
 }
 
 function replaceIgnoreTextWithPlaceholders(ignoreTexts, stringToEdit, reverse) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xlifftranslate",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1296,6 +1296,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -1626,6 +1631,14 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "sleep": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sleep/-/sleep-6.1.0.tgz",
+      "integrity": "sha512-Z1x4JjJxsru75Tqn8F4tnOFeEu3HjtITTsumYUiuz54sGKdISgLCek9AUlXlVVrkhltRFhNUsJDJE76SFHTDIQ==",
+      "requires": {
+        "nan": "^2.13.2"
       }
     },
     "snapdragon": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xlifftranslate",
   "description": "Translate xliff files using the Google Cloud Translation API",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": {
     "name": "Jason Ruesch",
     "email": "jason.ruesch@me.com"
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@google-cloud/translate": "^0.8.1",
-    "async": "^2.4.0",
+    "async": "^3.1.0",
     "cheerio": "^1.0.0-rc.2",
     "liftoff": "^2.3.0",
     "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "async": "^3.1.0",
     "cheerio": "^1.0.0-rc.2",
     "liftoff": "^2.3.0",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "sleep": "^6.1.0"
   }
 }


### PR DESCRIPTION
Adding throttling via async lib queue functionality. Adding sleep for task wait of 1/5 of a second after each translation. Queue of 1 is still to many requests. Need bulk requests in a future release.

Using a queue of more than 1 would give me rate-limit-exceeded. Without the sleep, it also goes too fast. 

Now its still really really fast, it just doesn't break.